### PR TITLE
Default to license of existing package.json

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -175,4 +175,6 @@ if (!package.author) {
   : prompt('author')
 }
 
-exports.license = prompt('license', 'BSD')
+if (!package.license) {
+  exports.license = prompt('license', 'BSD')
+}


### PR DESCRIPTION
Hi,

npm init does not use the license from an already existing package.json. Here is the fix.

Thank you,

```
    syranez
```
