### PR TITLE
Fix bug that causes `npm init` to silently fail.

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -16,6 +16,7 @@ function readDeps (test) { return function (cb) {
     if (er) return cb()
     var deps = {}
     var n = dir.length
+    if (n === 0) return cb(null, deps)
     dir.forEach(function (d) {
       if (d.match(/^\./)) return next()
       if (test !== isTestPkg(d))


### PR DESCRIPTION
**What I did**
1. create a new project directory && `cd` into it
2. create a new node_modules subdirectory (no longer necessary, but old habits die hard)
3. run `npm init` to create a pristine package.json

**What I expected**

To walk through a series of prompts to fill out a new package.json file and for that new file to get written to the current directory. Or at least an error if there was a problem.

**What actually happened**

After submitting a response to the "entry point" prompt, `npm init` silently exits with no error and no package.json created.
