### PR TITLE
Update default license to ISC

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -178,4 +178,4 @@ if (!package.author) {
 
 exports.license = prompt('license', package.license ||
                          config.get('init.license') ||
-                         'BSD-2-Clause')
+                         'ISC')


### PR DESCRIPTION
[npmconf now provides ISC as the default init.license](https://github.com/npm/npmconf/commit/160aa090f16159e0639a1a26f4115ed0ccca90e4#diff-093e169a50df5b94ced78237e58e4cf5R247), init-package-json could probably follow suit, in the case that init.license becomes unset?
