### PR TITLE
use save-prefix instead of hardcoded one

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -28,7 +28,7 @@ function readDeps (test) { return function (cb) {
         try { p = JSON.parse(p) }
         catch (e) { return next() }
         if (!p.version) return next()
-        deps[d] = '^' + p.version
+        deps[d] = config.get('save-prefix') + p.version
         return next()
       })
     })


### PR DESCRIPTION
It's mostly for consistency reasons, https://github.com/npm/npm/commit/64eefdfe26bb27db8dc90e3ab5d27a5ef18a4470 .
