### PR TITLE
Switch default repository GitHub URLs to https:// instead of git://

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -150,7 +150,7 @@ if (!package.repository) {
         else u = u.replace(/^\s*url = /, '')
       }
       if (u && u.match(/^git@github.com:/))
-        u = u.replace(/^git@github.com:/, 'git://github.com/')
+        u = u.replace(/^git@github.com:/, 'https://github.com/')
 
       return cb(null, prompt('git repository', u))
     })


### PR DESCRIPTION
Running `npm init` in an GitHub repo with an SSH URL (eg `git@github.com:user/repo.git`) defaults to using `git://` as its repository scheme in the resulting `package.json`.  

However, GitHub recommends & promotes using `https://` instead of `git://`.  From a support email written by Kyle, a GitHub employee:

>  There are several problems with the git:// protocol (completely unencrypted and open to man in the middle attacks for instance). HTTPS should be beneficial in every way for your uses (it's actually just as efficient as git:// since the SmartHTTP update 3 years ago). For the security reasons, we've decided to stop promoting the protocol. That being said, we will still support it — but you'll have to manually type in the URLs.

Side note: I did ask them to add the above to their [documentation](https://help.github.com/articles/which-remote-url-should-i-use) after they told me this, but no such luck.  I suppose it's effectively implied, though not very clearly.
