### PR TITLE
Add support for save-exact flag in npm-init

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -28,7 +28,7 @@ function readDeps (test) { return function (cb) {
         try { p = JSON.parse(p) }
         catch (e) { return next() }
         if (!p.version) return next()
-        deps[d] = config.get('save-prefix') + p.version
+        deps[d] = config.get('save-exact') ? p.version : config.get('save-prefix') + p.version
         return next()
       })
     })


### PR DESCRIPTION
If you did this without this patch:

```
$ npm config set save-exact true
$ npm install unexpected
$ npm init
```

You would get a package.json like this:

```json
{
  "dependencies": {
    "unexpected": "^4.1.2"
  }
}
```