### PR TITLE
Remote repository URL prefix should be removed

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -162,6 +162,12 @@ if (!package.repository) {
         if (!u.match(/^\s*url =/)) u = null
         else u = u.replace(/^\s*url = /, '')
       }
+
+      // Remote repository URL may be like "https://user@example.com/repo".
+      // Convert it to "https://example.com/repo".
+      if (u && u.match(/^(http(s)?:\/\/)([^@\/]*)@/))
+        u = u.replace( /^(http(s)?:\/\/)([^@\/]*)@/, '$1')
+
       if (u && u.match(/^git@github.com:/))
         u = u.replace(/^git@github.com:/, 'https://github.com/')
 


### PR DESCRIPTION
Remote repository URL may be like `https://user@example.com/owner/repo`. For example, when repository was cloned as following:

    $ git clone https://user@example.com/owner/repo

This is default repository URL style on [Bitbucket](https://bitbucket.org/), when `https://example.com/owner/repo` is more familiar for [GitHub](https://github.com) users.

Prefix should be removed because it is user-specific. Anybody is able to clone repository with prefixed URL, but git will not ask for user name before push, it will use prefix instead. There is no reason to put repository URL with prefix in `package.json`