### PR TITLE
Add supporting scope option

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -39,6 +39,9 @@ function readDeps (test) { return function (cb) {
 }}
 
 var name = package.name || basename
+if (config.get('scope')) {
+  name = '@' + config.get('scope') + '/' + name
+}
 exports.name = yes ? name : prompt('name', name)
 
 var version = package.version ||

--- a/test/scope.js
+++ b/test/scope.js
@@ -1,0 +1,35 @@
+var tap = require('tap')
+var init = require('../')
+var rimraf = require('rimraf')
+
+tap.test('the scope', function (t) {
+  var i = __dirname + '/basic.input'
+  var dir = __dirname
+  init(dir, i, {scope: 'foo'}, function (er, data) {
+    if (er) throw er
+    var expect =
+      { name: '@foo/test',
+        version: '1.2.5',
+        description: 'description',
+        author: 'me <em@i.l> (http://url)',
+        scripts: { test: 'make test' },
+        main: 'main.js',
+        config: { scope: 'foo' },
+        package: {} }
+    t.same(data, expect)
+    t.end()
+  })
+  setTimeout(function () {
+    process.stdin.emit('data', '@foo/test\n')
+  }, 50)
+  setTimeout(function () {
+    process.stdin.emit('data', 'description\n')
+  }, 100)
+  setTimeout(function () {
+    process.stdin.emit('data', 'yes\n')
+  }, 150)
+})
+
+tap.test('teardown', function (t) {
+  rimraf(__dirname + '/package.json', t.end.bind(t))
+})


### PR DESCRIPTION
Hi.
I like [this idea](https://github.com/npm/npm/issues/6749) so I created the patch supports scope option for npm init. But, if other better idea has come, I'll close this.

e.g.
```
$ npm init --scope=watilde
This utility blah blah...

name: (@watilde/some-package) 
```

Thanks.