### PR TITLE
npm init should read ~/.gitconfig and replace insteadOf aliases

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -151,6 +151,30 @@ function setupScripts (d, cb) {
   return cb(null, s)
 }
 
+function replacePrefix(u, conf) {
+  function getQuotes (s) {
+    if (/"/.test(s)) return s.match(/"(.*?)"/)[1];
+    return s;
+  }
+
+  // search .gitconfig for any insteadOf alias that match
+  // the url prefix if other than git, http or https and
+  // replace it accordingly
+
+  var prefix = u.indexOf(':')
+  if (prefix !== -1 && !u.match(/^git:|^http:|^https:/)) {
+    prefix = u.slice(0, prefix)
+    var alias = conf.indexOf('insteadOf = \"' + prefix + ':\"')
+    if (alias !== -1) {
+      var urlStart = conf.lastIndexOf('[url ', alias)
+      if (urlStart !== -1) {
+        alias = getQuotes(conf.substr(urlStart, alias - urlStart))
+        return u.replace(new RegExp('^' + prefix + ':'), alias)
+      }
+    }
+  }
+}
+
 if (!package.repository) {
   exports.repository = function (cb) {
     fs.readFile('.git/config', 'utf8', function (er, gconf) {
@@ -168,7 +192,19 @@ if (!package.repository) {
       if (u && u.match(/^git@github.com:/))
         u = u.replace(/^git@github.com:/, 'https://github.com/')
 
-      return cb(null, yes ? u : prompt('git repository', u))
+      var url = replacePrefix(u, gconf)
+      if (url) {
+        return cb(null, yes ? u : prompt('git repository', u))
+      } else {
+        var globalconf = path.join(osenv.home(), '.gitconfig')
+        fs.readFile(globalconf, 'utf8', function (er, gconf) {
+          if (!er && gconf) {
+            var url = replacePrefix(u, gconf)
+            if (url) u = url
+          }
+          return cb(null, yes ? u : prompt('git repository', u))
+        })
+      }
     })
   }
 }


### PR DESCRIPTION
`npm init` does not read global `.gitconfig` and replace _insteadOf_ aliases.

For example, from my `.gitconfig`:

```
[url "https://github.com/"]
	insteadOf = "gh:"

[url "https://github.com/bucaran/"]
	insteadOf = "@:"
```

Running `npm init` on a project that already has a remote using my aliases will incorrectly add `@:...` or `gh:...` to `package.json`.

This PR adds functionality to search the global `.gitconfig` (after searching `.git/config`) for any _insteadOf_ aliases that match the url prefix and will update the url accordingly. If the url prefix is already `git:`, `http:` or `https:` it will simply return with the available url.

I tried following the npm style and variable naming conventions, but let me know if there is anything _not_ "[funny](https://docs.npmjs.com/misc/coding-style)" about the code.