### PR TITLE
Concatenate error/warning message while validating name

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -54,7 +54,8 @@ if (scope) {
 exports.name =  yes ? name : prompt('name', name, function (data) {
   var its = validateName(data)
   if (its.validForNewPackages) return data
-  var er = new Error('Sorry, ' + its.errors.join(' and ') + '.')
+  var errors = [].concat(its.errors || []).concat(its.warnings || [])
+  var er = new Error('Sorry, ' + errors.join(' and ') + '.')
   er.notValid = true
   return er
 })


### PR DESCRIPTION
Validate-npm-package-name returns Object without error/warning key when no error/warning found.
It causes TypeError while initializing a new NPM package.

```
0 info it worked if it ends with ok
1 verbose cli [ '/Users/hoaxster/.nodebrew/iojs/v1.7.1/bin/iojs',
1 verbose cli   '/Users/hoaxster/.nodebrew/current/bin/npm',
1 verbose cli   'init',
1 verbose cli   '-V' ]
2 info using npm@2.8.3
3 info using node@v1.7.1
4 silly package data undefined
5 info init written successfully
6 verbose stack TypeError: Cannot read property 'join' of undefined
6 verbose stack     at /Users/hoaxster/.nodebrew/iojs/v1.7.1/lib/node_modules/npm/node_modules/init-package-json/default-input.js:51:44
6 verbose stack     at PromZard.<anonymous> (/Users/hoaxster/.nodebrew/iojs/v1.7.1/lib/node_modules/npm/node_modules/init-package-json/node_modules/promzard/promzard.js:226:19)
6 verbose stack     at Interface.onLine (/Users/hoaxster/.nodebrew/iojs/v1.7.1/lib/node_modules/npm/node_modules/read/lib/read.js:111:5)
6 verbose stack     at emitOne (events.js:77:13)
6 verbose stack     at Interface.emit (events.js:166:7)
6 verbose stack     at Interface._onLine (readline.js:198:10)
6 verbose stack     at Interface._line (readline.js:537:8)
6 verbose stack     at Interface._ttyWrite (readline.js:814:14)
6 verbose stack     at ReadStream.onkeypress (readline.js:93:10)
6 verbose stack     at emitTwo (events.js:87:13)
7 verbose cwd /Users/hoaxster/src/github.com/MisumiRize/HogeHoge
8 error Darwin 14.3.0
9 error argv "/Users/hoaxster/.nodebrew/iojs/v1.7.1/bin/iojs" "/Users/hoaxster/.nodebrew/current/bin/npm" "init" "-V"
10 error node v1.7.1
11 error npm  v2.8.3
12 error Cannot read property 'join' of undefined
13 error If you need help, you may report this error at:
13 error     <https://github.com/npm/npm/issues>
14 verbose exit [ 1, true ]
```

I was trying to create a package with uppercase letters, and I got this error.