### PR TITLE
Use validate-npm-package-license to check license values

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
 var glob = require('glob')
 var path = require('path')
+var validateLicense = require('validate-npm-package-license')
 var validateName = require('validate-npm-package-name')
 var npa = require('npm-package-arg')
 
@@ -216,4 +217,11 @@ var license = package.license ||
               config.get('init.license') ||
               config.get('init-license') ||
               'ISC'
-exports.license = yes ? license : prompt('license', license)
+exports.license = yes ? license : prompt('license', license, function (data) {
+  var its = validateLicense(data)
+  if (its.validForNewPackages) return data
+  var errors = (its.errors || []).concat(its.warnings || [])
+  var er = new Error('Sorry, ' + errors.join(' and ') + '.')
+  er.notValid = true
+  return er
+})

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "read": "~1.0.1",
     "read-package-json": "1 || 2",
     "semver": "2.x || 3.x || 4",
+    "validate-npm-package-license": "1.0.0-prerelease-2",
     "validate-npm-package-name": "^2.0.1"
   },
   "devDependencies": {

--- a/test/license.js
+++ b/test/license.js
@@ -1,0 +1,38 @@
+var test = require('tap').test
+var init = require('../')
+var rimraf = require('rimraf')
+var common = require('./lib/common')
+
+test('license', function (t) {
+  init(__dirname, '', {}, function (er, data) {
+    t.ok(!er, 'should not error')
+    var wanted = {
+      name: 'the-name',
+      version: '1.0.0',
+      description: '',
+      scripts: { test: 'echo "Error: no test specified" && exit 1' },
+      license: 'Apache-2.0',
+      author: '',
+      main: 'basic.js'
+    }
+    t.same(data, wanted)
+    t.end()
+  })
+  common.drive([
+    'the-name\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    'Apache\n',
+    'Apache-2.0\n',
+    'yes\n'
+  ])
+})
+
+test('teardown', function (t) {
+  rimraf(__dirname + '/package.json', t.end.bind(t))
+})


### PR DESCRIPTION
This PR uses a new [validate-npm-package-license](https://github.com/kemitchell/validate-npm-package-license) module to warn if a `license` property is not a valid SPDX license expression, and suggests correct expressions for common malformations of popular license identifiers.

I won't repeat the general comments about SPDX and current license metadata I made for npm/normalize-package-data#61 here. The two PRs are very much related. Both grow out of npm/npm#6241 and npm/npm#4473.

Best to all!