### PR TITLE
New tap and various test tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
+  - '0.10'
+  - '0.12'
+  - 'iojs'

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "npm": "^2",
     "rimraf": "^2.1.4",
-    "tap": "^0.7.1"
+    "tap": "^1.2.0"
   },
   "keywords": [
     "init",

--- a/test/basic.js
+++ b/test/basic.js
@@ -6,6 +6,7 @@ var test = require('tap').test
 
 test('the basics', function (t) {
   var i = path.join(__dirname, 'basic.input')
+  rimraf.sync(__dirname + '/package.json')
   init(__dirname, i, { foo: 'bar' }, function (er, data) {
     if (er) throw er
     var expect = {
@@ -18,6 +19,7 @@ test('the basics', function (t) {
       config: { foo: 'bar' },
       package: {}
     }
+    console.log('')
     t.same(data, expect)
     t.end()
   })

--- a/test/license.js
+++ b/test/license.js
@@ -5,7 +5,9 @@ var common = require('./lib/common')
 
 test('license', function (t) {
   init(__dirname, '', {}, function (er, data) {
-    t.ok(!er, 'should not error')
+    if (er)
+      throw er
+
     var wanted = {
       name: 'the-name',
       version: '1.0.0',
@@ -15,7 +17,8 @@ test('license', function (t) {
       author: '',
       main: 'basic.js'
     }
-    t.same(data, wanted)
+    console.log('')
+    t.has(data, wanted)
     t.end()
   })
   common.drive([

--- a/test/name-spaces.js
+++ b/test/name-spaces.js
@@ -4,8 +4,10 @@ var rimraf = require('rimraf')
 var common = require('./lib/common')
 
 test('spaces', function (t) {
+  rimraf.sync(__dirname + '/package.json')
   init(__dirname, '', {}, function (er, data) {
-    t.ok(!er, 'should not error')
+    if (er)
+      throw er
     var wanted = {
       name: 'the-name',
       version: '1.0.0',
@@ -15,7 +17,8 @@ test('spaces', function (t) {
       author: '',
       main: 'basic.js'
     }
-    t.same(data, wanted)
+    console.log('')
+    t.has(data, wanted)
     t.end()
   })
   common.drive([

--- a/test/name-uppercase.js
+++ b/test/name-uppercase.js
@@ -5,7 +5,9 @@ var common = require('./lib/common')
 
 test('uppercase', function (t) {
   init(__dirname, '', {}, function (er, data) {
-    t.ok(!er, 'should not error')
+    if (er)
+      throw er
+
     var wanted = {
       name: 'the-name',
       version: '1.0.0',
@@ -15,7 +17,8 @@ test('uppercase', function (t) {
       author: '',
       main: 'basic.js'
     }
-    t.same(data, wanted)
+    console.log('')
+    t.has(data, wanted)
     t.end()
   })
   common.drive([

--- a/test/scope-in-config-existing-name.js
+++ b/test/scope-in-config-existing-name.js
@@ -1,0 +1,30 @@
+var fs = require('fs')
+var path = require('path')
+
+var rimraf = require('rimraf')
+var tap = require('tap')
+
+var init = require('../')
+
+var json = {
+  name: '@already/scoped',
+  version: '1.0.0'
+}
+
+tap.test('with existing package.json', function (t) {
+  fs.writeFileSync(path.join(__dirname, 'package.json'), JSON.stringify(json, null, 2))
+  console.log(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'))
+  console.error('wrote json', json)
+  init(__dirname, __dirname, { yes: 'yes', scope: '@still' }, function (er, data) {
+    if (er) throw er
+
+    console.log('')
+    t.equal(data.name, '@still/scoped', 'new scope is added, basic name is kept')
+    t.end()
+  })
+})
+
+tap.test('teardown', function (t) {
+  rimraf.sync(path.join(__dirname, 'package.json'))
+  t.end()
+})

--- a/test/scope-in-config.js
+++ b/test/scope-in-config.js
@@ -21,22 +21,8 @@ tap.test('--yes with scope', function (t) {
   init(__dirname, __dirname, { yes: 'yes', scope: '@scoped' }, function (er, data) {
     if (er) throw er
 
-    t.same(EXPECT, data)
-    t.end()
-  })
-})
-
-var json = {
-  name: '@already/scoped',
-  version: '1.0.0'
-}
-
-tap.test('with existing package.json', function (t) {
-  fs.writeFileSync(path.join(__dirname, 'package.json'), JSON.stringify(json, null, 2))
-  init(__dirname, __dirname, { yes: 'yes', scope: '@still' }, function (er, data) {
-    if (er) throw er
-
-    t.equal(data.name, '@still/scoped', 'new scope is added, basic name is kept')
+    console.log('')
+    t.has(data, EXPECT)
     t.end()
   })
 })

--- a/test/scope.js
+++ b/test/scope.js
@@ -19,7 +19,8 @@ tap.test('the scope', function (t) {
   init(dir, i, {scope: '@foo'}, function (er, data) {
     if (er) throw er
 
-    t.same(EXPECT, data)
+    console.log('')
+    t.has(data, EXPECT)
     t.end()
   })
   setTimeout(function () {

--- a/test/yes-defaults.js
+++ b/test/yes-defaults.js
@@ -17,7 +17,7 @@ tap.test('--yes defaults', function (t) {
   init(__dirname, __dirname, {yes: 'yes'}, function (er, data) {
     if (er) throw er
 
-    t.same(EXPECT, data, 'used the default data')
+    t.has(data, EXPECT, 'used the default data')
     t.end()
   })
 })


### PR DESCRIPTION
This also splits the scope-in-config into two, since init() doesn't
reload the package.json on each call, so it can really only be done once
per process.