### PR TITLE
Remove extra property of error object in exports.version

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -72,7 +72,6 @@ exports.version = yes ?
     if (semver.valid(version)) return version
     var er = new Error('Invalid version: "' + version + '"')
     er.notValid = true
-    er.again = true
     return er
   })
 


### PR DESCRIPTION
Hi,

I missed to add a extra property to error object in [this PR](https://github.com/npm/init-package-json/pull/43), so I just removed it.

Thanks always!