### PR TITLE
Use validate-npm-package-license@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "read": "~1.0.1",
     "read-package-json": "1 || 2",
     "semver": "2.x || 3.x || 4",
-    "validate-npm-package-license": "1.0.0-prerelease-2",
+    "validate-npm-package-license": "^1.0.0",
     "validate-npm-package-name": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This tiny pull request replaces the dependency on a prerelease version of validate-npm-package-license with a dependency on `^1.0.0`.

The new 1.0.0 has better metadata and documentation, and is set up for continuous integration on a broader range of Node.js versions.