### PR TITLE
Configurable entry point with config::init.main

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -97,7 +97,10 @@ if (!package.main) {
       else
         f = f[0]
 
-      var index = f || 'index.js'
+      var index = f ||
+                  config.get('init.main') ||
+                  config.get('init-main') ||
+                  'index.js' 
       return cb(null, yes ? index : prompt('entry point', index))
     })
   }


### PR DESCRIPTION
I am afraid I am not sure how to make the test scripts work "as is" **and** with a configurable main parameter, so I only did the change to **default-input.js** :sob:. Hopefully this will be enough.
