### PR TITLE
Option for silence

### DIFF
--- a/init-package-json.js
+++ b/init-package-json.js
@@ -40,6 +40,8 @@ function init (dir, input, config, cb) {
     }
   }
 
+  var printf = config.get('silent') ? Function.prototype : console.log
+
   var package = path.resolve(dir, 'package.json')
   input = path.resolve(input)
   var pkg
@@ -106,17 +108,17 @@ function init (dir, input, config, cb) {
         var d = JSON.stringify(pkg, null, 2) + '\n'
         function write (yes) {
           fs.writeFile(package, d, 'utf8', function (er) {
-            if (!er && yes) console.log('Wrote to %s:\n\n%s\n', package, d)
+            if (!er && yes) printf('Wrote to %s:\n\n%s\n', package, d)
             return cb(er, pkg)
           })
         }
         if (ctx.yes) {
           return write(true)
         }
-        console.log('About to write to %s:\n\n%s\n', package, d)
+        printf('About to write to %s:\n\n%s\n', package, d)
         read({prompt:'Is this ok? ', default: 'yes'}, function (er, ok) {
           if (!ok || ok.toLowerCase().charAt(0) !== 'y') {
-            console.log('Aborted.')
+            printf('Aborted.')
           } else {
             return write()
           }

--- a/init-package-json.js
+++ b/init-package-json.js
@@ -40,8 +40,6 @@ function init (dir, input, config, cb) {
     }
   }
 
-  var printf = config.get('silent') ? Function.prototype : console.log
-
   var package = path.resolve(dir, 'package.json')
   input = path.resolve(input)
   var pkg
@@ -108,17 +106,19 @@ function init (dir, input, config, cb) {
         var d = JSON.stringify(pkg, null, 2) + '\n'
         function write (yes) {
           fs.writeFile(package, d, 'utf8', function (er) {
-            if (!er && yes) printf('Wrote to %s:\n\n%s\n', package, d)
+            if (!er && yes && !config.get('silent')) {
+              console.log('Wrote to %s:\n\n%s\n', package, d)
+            }
             return cb(er, pkg)
           })
         }
         if (ctx.yes) {
           return write(true)
         }
-        printf('About to write to %s:\n\n%s\n', package, d)
+        console.log('About to write to %s:\n\n%s\n', package, d)
         read({prompt:'Is this ok? ', default: 'yes'}, function (er, ok) {
           if (!ok || ok.toLowerCase().charAt(0) !== 'y') {
-            printf('Aborted.')
+            console.log('Aborted.')
           } else {
             return write()
           }

--- a/test/silent.js
+++ b/test/silent.js
@@ -1,0 +1,23 @@
+var tap = require('tap')
+var init = require('../')
+var rimraf = require('rimraf')
+
+var log = console.log
+var logged = false
+console.log = function () {
+  logged = true
+}
+
+tap.test('silent: true', function (t) {
+  init(__dirname, __dirname, {yes: 'yes', silent: true}, function (er, data) {
+    if (er) throw er
+
+    t.false(logged, 'did not print anything')
+    t.end()
+  })
+})
+
+tap.test('teardown', function (t) {
+  console.log = log
+  rimraf(__dirname + '/package.json', t.end.bind(t))
+})


### PR DESCRIPTION
This package needs a way to silence the output from `console.log` for programmatic usage. This patch suggests a new config option for that.

Usage:

```js
init(__dirname, __dirname, {yes: 'yes', silent: true}, function (er, data) {
  if (er) throw er

  // No other output.
})
```