### PR TITLE
Add lib directory to switch statement

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -129,6 +129,7 @@ exports.directories = function (cb) {
         case 'test': case 'tests': return res.test = d
         case 'doc': case 'docs': return res.doc = d
         case 'man': return res.man = d
+        case 'lib': return res.lib = d
       }
     })
     if (Object.keys(res).length === 0) res = undefined

--- a/test/npm-defaults.js
+++ b/test/npm-defaults.js
@@ -9,6 +9,9 @@ var EXPECTED = {
   name: 'test',
   version: '3.1.4',
   description: '',
+  directories: {
+    lib: 'lib'
+  },
   main: 'basic.js',
   scripts: {
     test: 'echo "Error: no test specified" && exit 1'


### PR DESCRIPTION
This change should allow us to add the `directories.lib` property by default, if a directory named "lib" exists in the directory npm init is called. Or at least that's the intention of this change.

If I've not found the correct area to change, feel free to close this, ideally with a pointer to a more appropriate package. This same structure exists in promzard<sup>[0]</sup>, and I'm happy to send a PR to add this change in there if keeping these two in sync is desired. 

[0] - https://github.com/npm/promzard/blob/9d655a45d1bc99ece500c1e0dadb10d39bfec57a/example/npm-init/init-input.js#L65-L80
