### PR TITLE
Remove redundant configuration get calls

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -15,6 +15,10 @@ function niceName (n) {
   return n.replace(/^node-|[.-]js$/g, '').toLowerCase()
 }
 
+function conf (name) {
+  return config.get(name) || config.get(name.split('.').join('-'))
+}
+
 function readDeps (test) { return function (cb) {
   fs.readdir('node_modules', function (er, dir) {
     if (er) return cb()
@@ -35,7 +39,7 @@ function readDeps (test) { return function (cb) {
         if (p._requiredBy) {
           if (!p._requiredBy.some(function (req) { return req === '#USER' })) return next()
         }
-        deps[d] = config.get('save-exact') ? p.version : config.get('save-prefix') + p.version
+        deps[d] = conf('save.exact') ? p.version : conf('save.prefix') + p.version
         return next()
       })
     })
@@ -47,7 +51,7 @@ function readDeps (test) { return function (cb) {
 
 var name = package.name || basename
 var spec = npa(name)
-var scope = config.get('scope')
+var scope = conf('scope')
 if (scope) {
   if (scope.charAt(0) !== '@') scope = '@' + scope
   if (spec.scope) {
@@ -65,10 +69,7 @@ exports.name =  yes ? name : prompt('name', name, function (data) {
   return er
 })
 
-var version = package.version ||
-              config.get('init.version') ||
-              config.get('init-version') ||
-              '1.0.0'
+var version = package.version || conf('init.version') || '1.0.0'
 exports.version = yes ?
   version :
   prompt('version', version, function (version) {
@@ -211,23 +212,15 @@ if (!package.keywords) {
 }
 
 if (!package.author) {
-  exports.author = config.get('init.author.name') ||
-                   config.get('init-author-name')
-  ? {
-      "name" : config.get('init.author.name') ||
-               config.get('init-author-name'),
-      "email" : config.get('init.author.email') ||
-                config.get('init-author-email'),
-      "url" : config.get('init.author.url') ||
-              config.get('init-author-url')
-    }
-  : yes ? '' : prompt('author')
+  var a = conf('init.author.name')
+  exports.author = a ? {
+    "name": a,
+    "email": conf('init.author.email'),
+    "url": conf('init.author.url')
+  } : yes ? '' : prompt('author')
 }
 
-var license = package.license ||
-              config.get('init.license') ||
-              config.get('init-license') ||
-              'ISC'
+var license = package.license || conf('init.license') || 'ISC'
 exports.license = yes ? license : prompt('license', license, function (data) {
   var its = validateLicense(data)
   if (its.validForNewPackages) return data


### PR DESCRIPTION
I found these double configuration calls confusing, so I went ahead and removed them. Only thing to note here is that this change also considers `'save.exact'` and `'save.prefix'`, which before have been ignored.
