### PR TITLE
Exclude dev deps from being auto-added to deps and vice versa

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -15,7 +15,7 @@ function niceName (n) {
   return n.replace(/^node-|[.-]js$/g, '').toLowerCase()
 }
 
-function readDeps (test) { return function (cb) {
+function readDeps (test, excluded) { return function (cb) {
   fs.readdir('node_modules', function (er, dir) {
     if (er) return cb()
     var deps = {}
@@ -23,7 +23,7 @@ function readDeps (test) { return function (cb) {
     if (n === 0) return cb(null, deps)
     dir.forEach(function (d) {
       if (d.match(/^\./)) return next()
-      if (test !== isTestPkg(d))
+      if (test !== isTestPkg(d) || excluded[d])
         return next()
 
       var dp = path.join(dirname, 'node_modules', d, 'package.json')
@@ -137,11 +137,11 @@ exports.directories = function (cb) {
 }
 
 if (!package.dependencies) {
-  exports.dependencies = readDeps(false)
+  exports.dependencies = readDeps(false, package.devDependencies || {})
 }
 
 if (!package.devDependencies) {
-  exports.devDependencies = readDeps(true)
+  exports.devDependencies = readDeps(true, package.dependencies || {})
 }
 
 // MUST have a test script!

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "validate-npm-package-name": "^2.0.1"
   },
   "devDependencies": {
+    "mkdirp": "^0.5.1",
     "npm": "^2",
     "rimraf": "^2.1.4",
     "tap": "^1.2.0"

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -1,0 +1,60 @@
+var tap = require('tap')
+var init = require('../')
+var path = require('path')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var fs = require('fs')
+
+var EXPECT = {
+  name: 'test-deps',
+  version: '1.0.0',
+  description: '',
+  author: '',
+  scripts: { test: 'mocha' },
+  main: 'index.js',
+  keywords: [],
+  license: 'ISC',
+  dependencies: {
+    'tap': '*'
+  },
+  devDependencies: {
+    'mocha': '^1.0.0'
+  }
+}
+
+var origwd = process.cwd()
+var testdir = path.resolve(__dirname, 'test-deps')
+mkdirp.sync(testdir)
+process.chdir(testdir)
+
+fs.writeFileSync(path.resolve(testdir, 'package.json'), JSON.stringify({
+  dependencies: {
+    'tap': '*'
+  }
+}))
+
+var fakedeps = ['mocha', 'tap', 'async', 'foobar']
+
+fakedeps.forEach(function(dep) {
+  var depdir = path.resolve(testdir, 'node_modules', dep)
+  mkdirp.sync(depdir)
+
+  fs.writeFileSync(path.resolve(depdir, 'package.json'), JSON.stringify({
+    name: dep,
+    version: '1.0.0'
+  }))
+})
+
+tap.test('read in dependencies and dev deps', function (t) {
+  init(testdir, testdir, {yes: 'yes', 'save-prefix': '^'}, function (er, data) {
+    if (er) throw er
+
+    t.same(data, EXPECT, 'used the correct dependency information')
+    t.end()
+  })
+})
+
+tap.test('teardown', function (t) {
+  process.chdir(origwd)
+  rimraf(testdir, t.end.bind(t))
+})


### PR DESCRIPTION
Do not add folders from node_modules/ which are present in the existing package.json’s `devDependencies` field to the `dependencies` field of the newly generated package.json, and vice versa.

Fixes: https://github.com/npm/npm/issues/12260
