### PR TITLE
Disambiguate `name:` prompt

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -56,7 +56,7 @@ if (scope) {
     name = scope + '/' + name
   }
 }
-exports.name =  yes ? name : prompt('name', name, function (data) {
+exports.name =  yes ? name : prompt('package name', name, function (data) {
   var its = validateName(data)
   if (its.validForNewPackages) return data
   var errors = (its.errors || []).concat(its.warnings || [])


### PR DESCRIPTION
Hi there! 👋

While working through the `how-to-npm` Nodeschool workshopper it
was discovered that the `name:` prompt is a bit confusing for
newcomers, as it could also be interpreted as referring to the
npm account name (or similar). This changes the prompt to use
`package name:`.