### PR TITLE
Fix for cordova-lib exception CB-13451

### DIFF
--- a/init-package-json.js
+++ b/init-package-json.js
@@ -61,7 +61,12 @@ function init (dir, input, config, cb) {
     if (!pkg.version || !semver.valid(pkg.version))
       delete pkg.version
 
-    ctx.package = pkg
+    // Some projects (like cordova-lib) have begun replacing the 'package' keyword in favour of 'pkg' as es-lint complains otherwise.
+    // this means that e.g. PromZard files in CordovaLib have started falling over because the 'package' variable no longer exists.
+    // In order to maintain backward compatibility with any packages still allowing the 'package' keyword, but also allowing init-package-json
+    // to work with the 'pkg' naming convention, add both to the context.
+    ctx.package = pkg;
+    ctx.pkg = pkg;
     ctx.config = config || {}
 
     // make sure that the input is valid.


### PR DESCRIPTION
Some projects (like cordova-lib) have begun replacing the 'package' keyword in favour of 'pkg' as es-lint complains otherwise; this means that e.g. PromZard files in CordovaLib have started falling over because the 'package' variable no longer exists. In order to maintain backward compatibility with any packages still making use of init-package-json and allowing the 'package' keyword, but also allowing init-package-json to work with the 'pkg' naming convention in cordova-lib, I've added both to the context. It feels a bit hacky to add a line of code to a generic package like init-package-json just to accomodate cordova-lib, but unless the cordova-lib maintainers reconfigure their Travis setup to disable the es-lint checks, it won't be fixable in there (I already tried...).