### PR TITLE
Improve nice name function: replace all spaces

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -12,7 +12,7 @@ function isTestPkg (p) {
 }
 
 function niceName (n) {
-  return n.replace(/^node-|[.-]js$/g, '').replace(' ', '-').toLowerCase()
+  return n.replace(/^node-|[.-]js$/g, '').replace(/ /g, '-').toLowerCase()
 }
 
 function readDeps (test, excluded) { return function (cb) {


### PR DESCRIPTION
In #71 used `String.Object.replace()` function, but the function, if first argument is string, replaces only first occurrence. Using regex for first argument allow to replace all occurrences.

Before:
![default](https://user-images.githubusercontent.com/32711843/37148368-4def7cf4-22db-11e8-9438-14180e0bb9f3.png)
After:
![default](https://user-images.githubusercontent.com/32711843/37148760-ad11fe86-22dc-11e8-967c-513444f0a77f.png)
