### PR TITLE
Switch to using MIT as default license

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -233,7 +233,7 @@ if (!package.author) {
 var license = package.license ||
               config.get('init.license') ||
               config.get('init-license') ||
-              'ISC'
+              'MIT'
 exports.license = yes ? license : prompt('license', license, function (data) {
   var its = validateLicense(data)
   if (its.validForNewPackages) return data

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -13,7 +13,7 @@ var EXPECT = {
   scripts: { test: 'mocha' },
   main: 'index.js',
   keywords: [],
-  license: 'ISC',
+  license: 'MIT',
   dependencies: {
     'tap': '*'
   },

--- a/test/name-spaces.js
+++ b/test/name-spaces.js
@@ -13,7 +13,7 @@ test('spaces', function (t) {
       version: '1.0.0',
       description: '',
       scripts: { test: 'echo "Error: no test specified" && exit 1' },
-      license: 'ISC',
+      license: 'MIT',
       author: '',
       main: 'basic.js'
     }

--- a/test/name-uppercase.js
+++ b/test/name-uppercase.js
@@ -13,7 +13,7 @@ test('uppercase', function (t) {
       version: '1.0.0',
       description: '',
       scripts: { test: 'echo "Error: no test specified" && exit 1' },
-      license: 'ISC',
+      license: 'MIT',
       author: '',
       main: 'basic.js'
     }

--- a/test/scope-in-config.js
+++ b/test/scope-in-config.js
@@ -14,7 +14,7 @@ var EXPECT = {
     scripts: { test: 'echo \"Error: no test specified\" && exit 1' },
     main: 'basic.js',
     keywords: [],
-    license: 'ISC'
+    license: 'MIT'
 }
 
 tap.test('--yes with scope', function (t) {

--- a/test/yes-defaults.js
+++ b/test/yes-defaults.js
@@ -10,7 +10,7 @@ var EXPECT = {
     scripts: { test: 'echo "Error: no test specified" && exit 1' },
     main: 'basic.js',
     keywords: [],
-    license: 'ISC'
+    license: 'MIT'
 }
 
 tap.test('--yes defaults', function (t) {


### PR DESCRIPTION
**What is this?**
This changes the default license to MIT instead of the existing default, ISC.

**Why is this?**
This change brings the package.json defaults in line with current community preferences. 

Looking at the licenses of top 180 most depended upon packages and their dependencies (essentially the first five pages of https://www.npmjs.com/browse/depended), MIT is used almost ten times more than ISC (1580 vs. 175, respectively)

>npx legally lodash request chalk react express async commander moment bluebird debug prop-types react-dom underscore fs-extra mkdirp babel-runtime body-parser uuid colors glob classnames yargs jquery minimist rxjs webpack axios babel-core through2 yeoman-generator q inquirer cheerio aws-sdk tslib winston redux vue semver babel-loader @angular/core rimraf gulp-util object-assign core-js babel-preset-es2015 gulp @angular/common zone.js babel-polyfill shelljs eslint css-loader dotenv react-redux js-yaml style-loader @angular/platform-browser mocha @angular/compiler mongoose ramda coffee-script superagent mongodb @angular/http handlebars request-promise yosay @angular/forms socket.io @angular/platform-browser-dynamic babel-eslint redis ember-cli-babel typescript file-loader @types/node joi @angular/router chai xml2js immutable co ejs autoprefixer morgan babel-preset-react node-fetch eslint-plugin-import promise node-uuid eslint-plugin-react extract-text-we$ npx legal$ npx legally lodash request chalk react express async commander moment blueb$ npx legall$ npx legally lodash request chalk react express async commander moment blue$ np$ npx legally lodash request chalk react express async commander mo$ npx legally lodash request chalk react express $ npx legally lodash request cha$ npx legally lo$ npx legally lodash request chalk react express async commander moment bluebird debug prop-types react-dom underscore fs-extra mkdirp babel-runtime body-parser uuid colors glob classnames yargs jquery minimist rxjs webpack axios babel-core through2 yeoman-generator q inquirer cheerio aws-sdk tslib winston redux vue semver babel-loader @angular/core rimraf gulp-util object-assign core-js babel-preset-es2015 gulp @angular/common zone.js babel-polyfill shelljs eslint css-loader dotenv react-redux js-yaml style-loader @angular/platform-browser mocha @angular/compiler mongoose ramda coffee-script superagent mongodb @angular/http handlebars request-promise yosay @angular/forms socket.io @angular/platform-browser-dynamic babel-eslint redis ember-cli-babel typescript file-loader @types/node joi @angular/router chai xml2js immutable co ejs autoprefixer morgan babel-preset-react node-fetch eslint-plugin-import promise node-uuid eslint-plugin-react extract-text-webpack-plugin url-loader cookie-parser optimist ws webpack-dev-server node-sass bootstrap jsonwebtoken path babel-preset-env html-webpack-plugin postcss-loader whatwg-fetch extend react-router angular babel-cli mysql nan mime qs es6-promise marked chokidar ora postcss @angular/animations uglify-js isomorphic-fetch reflect-metadata cors meow compression jade eslint-plugin-jsx-a11y less loader-utils redux-thunk fs jest moment-timezone bunyan minimatch react-router-dom pg socket.io-client underscore.string styled-components sass-loader del browserify validator babel-plugin-transform-runtime babel-preset-stage-0 prompt npm gulp-rename cross-spawn express-session koa xtend invariant nodemailer passport babel-jest config eslint-loader update-notifier resolve grunt jsdom eslint-plugin-flowtype source-map-support babel-register ember-cli-htmlbars boom font-awesome react-dev-utils serve-favicon case-sensitive-paths-webpack-plugin graphql d3 sequelize babel-plugin-transform-class-properties babel-plugin-transform-object-rest-spread query-string

![image](https://user-images.githubusercontent.com/921683/45137041-d5171480-b15b-11e8-9baa-b084af62d8fd.png)

**Prior Art**
https://github.com/npm/npm/issues/15845 Was an issue that was bot-closed in early 2017 due to inactivity.