### PR TITLE
Change all spaces for "-" in default package name

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -45,7 +45,7 @@ function readDeps (test, excluded) { return function (cb) {
   })
 }}
 
-var name = package.name || basename
+var name = niceName(package.name || basename)
 var spec
 try {
   spec = npa(name)
@@ -61,7 +61,7 @@ if (scope) {
     name = scope + '/' + name
   }
 }
-exports.name =  yes ? niceName(name) : prompt('package name', niceName(name), function (data) {
+exports.name =  yes ? name : prompt('package name', name, function (data) {
   var its = validateName(data)
   if (its.validForNewPackages) return data
   var errors = (its.errors || []).concat(its.warnings || [])

--- a/test/name-default-formatting.js
+++ b/test/name-default-formatting.js
@@ -1,0 +1,31 @@
+const { resolve } = require('path')
+const t = require('tap')
+const init = require('../')
+
+t.test('replaces spaces for hyphens', t => {
+  const dir = t.testdir({
+    'name with spaces': {}
+  })
+
+  init(resolve(dir, 'name with spaces'), '', { yes: 'yes' }, (er, data) => {
+    if (er)
+      throw er
+
+    t.equal(data.name, 'name-with-spaces')
+    t.end()
+  })
+})
+
+t.test('removes node- and .js', t => {
+  const dir = t.testdir({
+    'node-package.js': {}
+  })
+
+  init(resolve(dir, 'node-package.js'), '', { yes: 'yes' }, (er, data) => {
+    if (er)
+      throw er
+
+    t.equal(data.name, 'package')
+    t.end()
+  })
+})

--- a/test/name-spaces.js
+++ b/test/name-spaces.js
@@ -3,7 +3,7 @@ const t = require('tap')
 const init = require('../')
 const common = require('./lib/common')
 
-t.skip('single space', t => {
+t.test('single space', t => {
   const dir = t.testdir({})
 
   init(dir, '', {}, (er, data) => {
@@ -16,7 +16,7 @@ t.skip('single space', t => {
       scripts: { test: 'echo "Error: no test specified" && exit 1' },
       license: 'ISC',
       author: '',
-      main: 'basic.js'
+      main: 'index.js'
     }
     console.log('')
     t.has(data, wanted)
@@ -25,6 +25,7 @@ t.skip('single space', t => {
 
   common.drive([
     'the name\n',
+    'the-name\n',
     '\n',
     '\n',
     '\n',
@@ -37,7 +38,7 @@ t.skip('single space', t => {
   ])
 })
 
-t.skip('multiple spaces', t => {
+t.test('multiple spaces', t => {
   const dir = t.testdir({})
 
   init(dir, '', {}, (er, data) => {
@@ -50,7 +51,7 @@ t.skip('multiple spaces', t => {
       scripts: { test: 'echo "Error: no test specified" && exit 1' },
       license: 'ISC',
       author: '',
-      main: 'basic.js'
+      main: 'index.js'
     }
     console.log('')
     t.has(data, wanted)
@@ -59,6 +60,7 @@ t.skip('multiple spaces', t => {
 
   common.drive([
     'the name should be this\n',
+    'the-name-should-be-this\n',
     '\n',
     '\n',
     '\n',


### PR DESCRIPTION
Hi npm! I've improved the default package name you get from `npm init` by making sure to **remove all the spaces** and also formatting the name when the `yes` option is used. I've also added some tests to **test the default name formatting**. That's the gist of it so if you are in a rush, no need to read any further!

Edit: As soon as I submitted this, I realized that there are already pull requests open to make these changes. If you rather go with those instead I could change this to just add the tests.

---------------------------------------------------------

Some context in case you've got some extra time: I teach a Web development course to beginners and of course we use npm a ton. It's pretty common when learning about `npm init` that they create folders with spaces and uppercase letters in the name. It used to be extra friction when the default package name given by `npm init` wouldn't work. Thanks for fixing most of those problems already!

With these changes, small as they may be, it should be a lot less painful for beginners to get started with npm.