### PR TITLE
Replace and normalize all spaces in the directory name (npm init)

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -12,7 +12,7 @@ function isTestPkg (p) {
 }
 
 function niceName (n) {
-  return n.replace(/^node-|[.-]js$/g, '').replace(' ', '-').toLowerCase()
+  return n.replace(/^node-|[.-]js$/g, '').replace(/\s+/g, ' ').replace(/ /g, '-').toLowerCase()
 }
 
 function readDeps (test, excluded) { return function (cb) {


### PR DESCRIPTION
The previous function did not replace all the spaces, only the first one. In addition, it normalizes spaces in case of having multiples in the directory name.

Example:
"My aw eSom e P roJ      EcT"

Before:
"my-aw esom e p roj      ect"

Now:
"my-awesome-project"