### PR TITLE
Don't add main field if no file exists.

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -111,8 +111,7 @@ if (!package.main) {
       else
         f = f[0]
 
-      var index = f || 'index.js'
-      return cb(null, yes ? index : prompt('entry point', index))
+      return cb(null, yes ? f : prompt('entry point', f))
     })
   }
 }

--- a/init-package-json.js
+++ b/init-package-json.js
@@ -98,6 +98,10 @@ function init (dir, input, config, cb) {
         if (!pkg.repository)
           delete pkg.repository
 
+        // if the main is empty, remove it.
+        if (!pkg.main)
+          delete pkg.main
+
         // readJson filters out empty descriptions, but init-package-json
         // traditionally leaves them alone
         if (!pkg.description)

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -11,7 +11,6 @@ var EXPECT = {
   description: '',
   author: '',
   scripts: { test: 'mocha' },
-  main: 'index.js',
   keywords: [],
   license: 'ISC',
   dependencies: {


### PR DESCRIPTION
For many projects, the `"main": "index.js"` field generated by `npm init` is never used (non-library projects such as web frontends).

This can confuse tools that use `main/module/browser` as configuration: https://github.com/parcel-bundler/parcel/issues/5243