### PR TITLE
fix: package.json saving optional deps

### DIFF
--- a/init-package-json.js
+++ b/init-package-json.js
@@ -103,7 +103,7 @@ function init (dir, input, config, cb) {
         if (!pkg.description)
           pkg.description = data.description
 
-        var d = JSON.stringify(pkg, null, 2) + '\n'
+        var d = JSON.stringify(updateDeps(pkg), null, 2) + '\n'
         function write (yes) {
           fs.writeFile(packageFile, d, 'utf8', function (er) {
             if (!er && yes && !config.get('silent')) {
@@ -130,6 +130,20 @@ function init (dir, input, config, cb) {
     })
   })
 
+}
+
+function updateDeps(depsData) {
+  // optionalDependencies don't need to be repeated in two places
+  if (depsData.dependencies) {
+    if (depsData.optionalDependencies) {
+      for (const name of Object.keys(depsData.optionalDependencies))
+        delete depsData.dependencies[name]
+    }
+    if (Object.keys(depsData.dependencies).length === 0)
+      delete depsData.dependencies
+  }
+
+  return depsData
 }
 
 // turn the objects into somewhat more humane strings.

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -19,6 +19,9 @@ var EXPECT = {
   },
   devDependencies: {
     'mocha': '^1.0.0'
+  },
+  optionalDependencies: {
+    'abbrev': '*'
   }
 }
 
@@ -29,7 +32,11 @@ process.chdir(testdir)
 
 fs.writeFileSync(path.resolve(testdir, 'package.json'), JSON.stringify({
   dependencies: {
+    'abbrev': '*',
     'tap': '*'
+  },
+  optionalDependencies: {
+    'abbrev': '*'
   }
 }))
 


### PR DESCRIPTION
When saving over existing files that contains `optionalDependencies` it
should avoid also saving that dep to `dependencies`, respecting our docs
recommendation on it:

    Entries in optionalDependencies will override entries of the same
    name in dependencies, so it's usually best to only put in one place.

This patches this UX problem by adding an extra check that will avoid
adding a dependency to the package.json `dependencies` object in case
that package is already listed under `optionalDependencies`.

Relates to: https://github.com/npm/arborist/pull/219
Fixes: https://github.com/npm/cli/issues/724
