### PR TITLE
fixed issue #2996 "On npm init, the name of the folder from which the function is called, only the first space gets replaced by a space" 

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -11,8 +11,9 @@ function isTestPkg (p) {
   return !!p.match(/^(expresso|mocha|tap|coffee-script|coco|streamline)$/)
 }
 
+// creates the default package name, which follows naming standards
 function niceName (n) {
-  return n.replace(/^node-|[.-]js$/g, '').replace(/\s+/g, ' ').replace(/ /g, '-').toLowerCase()
+  return n.replace(/^node-|[.-]js$/g, '').replace(/\s+/g, '-').toLowerCase();
 }
 
 function readDeps (test, excluded) { return function (cb) {


### PR DESCRIPTION
# Fixed [#2996](https://github.com/npm/cli/issues/2996)

## Open Issue [#2996](https://github.com/npm/cli/issues/2996) fixed:
now the default package name on "npm init" will have all the spaces converted to dashes as expected instead of just the first space, when multiple spaces are occured.

## How:
The "default-input.js" file in "init-package-json" handles the above functionality, and the changes are done to suit the expected behaviour.

Please look at the "init-package-json" file for a detailed view of the specific changes.


## References
Example:
earlier on "npm init" if folder were named as "hello foo bar", package name would default as " hello-foo bar"

After fix:
on "npm init", if folder name were "hello foo bar", package name defaults as "hello-foo-bar"
