### PR TITLE
fix: bin script path

### DIFF
--- a/default-input.js
+++ b/default-input.js
@@ -123,14 +123,11 @@ if (!package.bin) {
       // no bins
       if (er) return cb()
       // just take the first js file we find there, or nada
-      var r = d.filter(function (f) {
-          return f.match(/\.js$/)
-      })
-      if (r.length) {
-        // fix bin script path
-        r[0] = './bin/' + r[0]
+      let r = d.find(f => f.match(/\.js$/))
+      if (r) {
+        r = `bin/${r}`
       }
-      return cb(null, r[0])
+      return cb(null, r)
     })
   }
 }

--- a/default-input.js
+++ b/default-input.js
@@ -128,7 +128,7 @@ if (!package.bin) {
       })
       if (r.length) {
         // fix bin script path
-        r[0] = 'bin/' + r[0]
+        r[0] = './bin/' + r[0]
       }
       return cb(null, r[0])
     })

--- a/default-input.js
+++ b/default-input.js
@@ -123,9 +123,14 @@ if (!package.bin) {
       // no bins
       if (er) return cb()
       // just take the first js file we find there, or nada
-      return cb(null, d.filter(function (f) {
-        return f.match(/\.js$/)
-      })[0])
+      var r = d.filter(function (f) {
+          return f.match(/\.js$/)
+      })
+      if (r.length) {
+        // fix bin script path
+        r[0] = 'bin/' + r[0]
+      }
+      return cb(null, r[0])
     })
   }
 }

--- a/test/bins.js
+++ b/test/bins.js
@@ -1,0 +1,31 @@
+var common = require('./lib/common')
+var init = require('../')
+var test = require('tap').test
+
+test('auto bin population', function (t) {
+  const dir = t.testdir({
+    bin: {
+      'run.js': ''
+    }
+  })
+  init(dir, '', {}, (er, data) => {
+    if (er)
+      throw er
+    console.log(data)
+    t.same(data.bin, { 'auto-bin-test': 'bin/run.js' }, 'bin auto populated with correct path')
+    t.end()
+  })
+  common.drive([
+    'auto-bin-test\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    '\n',
+    'yes\n'
+  ])
+})
+


### PR DESCRIPTION
The auto-population of `bin` does not include `./bin/` in its own entry.  This fixes that.

This is built off of https://github.com/npm/init-package-json/pull/79, adding tests and tweaking the code to deal w/ the fact that the `./` is stripped out anyways.