### PR TITLE
fix: fix issue with retrieving repository URL

### DIFF
--- a/lib/default-input.js
+++ b/lib/default-input.js
@@ -206,9 +206,9 @@ if (!package.repository) {
     const i = lines.indexOf('[remote "origin"]')
 
     if (i !== -1) {
-      url = gconf[i + 1]
+      url = lines[i + 1]
       if (!url.match(/^\s*url =/)) {
-        url = gconf[i + 2]
+        url = lines[i + 2]
       }
       if (!url.match(/^\s*url =/)) {
         url = null

--- a/test/repository.js
+++ b/test/repository.js
@@ -1,3 +1,4 @@
+const { exec } = require('node:child_process')
 const t = require('tap')
 const { setup, child, isChild } = require('./fixtures/setup')
 
@@ -33,5 +34,51 @@ t.test('license', async (t) => {
     },
     main: 'index.js',
   }
+  t.has(data, wanted)
+})
+
+const getRemoteURL = () => new Promise((res, rej) => {
+  exec('git config --get remote.origin.url', (err, stdout) => {
+    if (err) {
+      rej(err)
+    } else {
+      res(stdout.trim())
+    }
+  })
+})
+
+t.test('parse repository from git config', async (t) => {
+  const { data } = await setup(t, __filename, {
+    inputs: [
+      'the-name', // package name
+      '', // version
+      '', // description
+      '', // entry point
+      '', // test
+      '', // git repo
+      '', // keywords
+      '', // author
+      '', // license
+      'yes', // about to write
+    ],
+  })
+  const remoteURL = await getRemoteURL()
+
+  const wanted = {
+    name: 'the-name',
+    version: '1.0.0',
+    description: '',
+    scripts: { test: 'echo "Error: no test specified" && exit 1' },
+    author: '',
+    main: 'index.js',
+  }
+
+  if (remoteURL) {
+    wanted.repository = {
+      type: 'git',
+      url: `git+${remoteURL}`,
+    }
+  }
+
   t.has(data, wanted)
 })

--- a/test/repository.js
+++ b/test/repository.js
@@ -66,20 +66,11 @@ t.test('license', async (t) => {
   t.has(data, wanted)
 })
 
-t.test('parse repository from git config', async (t) => {
-  await updateContent(`
-[core]
-    repositoryformatversion = 0
-    filemode = true
-    bare = false
-    logallrefupdates = true
-[remote "origin"]
+t.test('parse repository from git config with HTTPS URL', async (t) => {
+  await updateContent(`[remote "origin"]
     url = https://github.com/npm/init-package-json.git
     fetch = +refs/heads/*:refs/remotes/origin/*
-[branch "main"]
-    remote = origin
-    merge = refs/heads/main
-`)
+  `)
 
   const { data } = await setup(t, __filename, {
     inputs: [
@@ -104,8 +95,140 @@ t.test('parse repository from git config', async (t) => {
     author: '',
     repository: {
       type: 'git',
-      url: `git+https://github.com/npm/init-package-json.git`,
+      url: 'git+https://github.com/npm/init-package-json.git',
     },
+    main: 'index.js',
+  }
+
+  t.has(data, wanted)
+})
+
+t.test('parse repository from git config with SSH URL', async (t) => {
+  await updateContent(`[remote "origin"]
+    url = git@github.com:npm/init-package-json.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+  `)
+
+  const { data } = await setup(t, __filename, {
+    inputs: [
+      'the-name', // package name
+      '', // version
+      '', // description
+      '', // entry point
+      '', // test
+      '', // git repo
+      '', // keywords
+      '', // author
+      '', // license
+      'yes', // about to write
+    ],
+  })
+
+  const wanted = {
+    name: 'the-name',
+    version: '1.0.0',
+    description: '',
+    scripts: { test: 'echo "Error: no test specified" && exit 1' },
+    author: '',
+    repository: {
+      type: 'git',
+      url: 'git+https://github.com/npm/init-package-json.git',
+    },
+    main: 'index.js',
+  }
+
+  t.has(data, wanted)
+})
+
+t.test('handle missing remote origin section', async (t) => {
+  await updateContent(`[core]
+    repositoryformatversion = 0
+    filemode = true
+    bare = false
+    logallrefupdates = true
+  `)
+
+  const { data } = await setup(t, __filename, {
+    inputs: [
+      'the-name', // package name
+      '', // version
+      '', // description
+      '', // entry point
+      '', // test
+      '', // git repo
+      '', // keywords
+      '', // author
+      '', // license
+      'yes', // about to write
+    ],
+  })
+
+  const wanted = {
+    name: 'the-name',
+    version: '1.0.0',
+    description: '',
+    scripts: { test: 'echo "Error: no test specified" && exit 1' },
+    author: '',
+    main: 'index.js',
+  }
+
+  t.has(data, wanted)
+})
+
+t.test('handle invalid git config format', async (t) => {
+  await updateContent(`invalid config content`)
+
+  const { data } = await setup(t, __filename, {
+    inputs: [
+      'the-name', // package name
+      '', // version
+      '', // description
+      '', // entry point
+      '', // test
+      '', // git repo
+      '', // keywords
+      '', // author
+      '', // license
+      'yes', // about to write
+    ],
+  })
+
+  const wanted = {
+    name: 'the-name',
+    version: '1.0.0',
+    description: '',
+    scripts: { test: 'echo "Error: no test specified" && exit 1' },
+    author: '',
+    main: 'index.js',
+  }
+
+  t.has(data, wanted)
+})
+
+t.test('handle non-existent config file gracefully', async (t) => {
+  // Do not create the config file to simulate non-existent file
+
+  const { data } = await setup(t, __filename, {
+    inputs: [
+      'the-name', // package name
+      '', // version
+      '', // description
+      '', // entry point
+      '', // test
+      '', // git repo
+      '', // keywords
+      '', // author
+      '', // license
+      'yes', // about to write
+    ],
+  })
+
+  const wanted = {
+    name: 'the-name',
+    version: '1.0.0',
+    description: '',
+    scripts: { test: 'echo "Error: no test specified" && exit 1' },
+    author: '',
     main: 'index.js',
   }
 

--- a/test/repository.js
+++ b/test/repository.js
@@ -1,10 +1,39 @@
-const { exec } = require('node:child_process')
+const path = require('node:path')
+const fs = require('fs/promises')
 const t = require('tap')
 const { setup, child, isChild } = require('./fixtures/setup')
 
 if (isChild()) {
   return child()
 }
+
+const cwd = process.cwd()
+let updateContent
+
+t.beforeEach(async () => {
+  const testdir = t.testdir({
+    '.git': {
+      config: '',
+    },
+  })
+
+  updateContent = (content) => {
+    const gitConfigPath = path.resolve(testdir, '.git/config')
+    return fs.writeFile(gitConfigPath, content)
+  }
+
+  // Copy package.json
+  await fs.copyFile(
+    path.resolve(cwd, 'package.json'),
+    path.resolve(testdir, 'package.json')
+  )
+
+  process.chdir(testdir)
+})
+
+t.afterEach(() => {
+  process.chdir(cwd)
+})
 
 t.test('license', async (t) => {
   const { data } = await setup(t, __filename, {
@@ -37,17 +66,21 @@ t.test('license', async (t) => {
   t.has(data, wanted)
 })
 
-const getRemoteURL = () => new Promise((res, rej) => {
-  exec('git config --get remote.origin.url', (err, stdout) => {
-    if (err) {
-      rej(err)
-    } else {
-      res(stdout.trim())
-    }
-  })
-})
-
 t.test('parse repository from git config', async (t) => {
+  await updateContent(`
+[core]
+    repositoryformatversion = 0
+    filemode = true
+    bare = false
+    logallrefupdates = true
+[remote "origin"]
+    url = https://github.com/npm/init-package-json.git
+    fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "main"]
+    remote = origin
+    merge = refs/heads/main
+`)
+
   const { data } = await setup(t, __filename, {
     inputs: [
       'the-name', // package name
@@ -62,7 +95,6 @@ t.test('parse repository from git config', async (t) => {
       'yes', // about to write
     ],
   })
-  const remoteURL = await getRemoteURL()
 
   const wanted = {
     name: 'the-name',
@@ -70,14 +102,11 @@ t.test('parse repository from git config', async (t) => {
     description: '',
     scripts: { test: 'echo "Error: no test specified" && exit 1' },
     author: '',
-    main: 'index.js',
-  }
-
-  if (remoteURL) {
-    wanted.repository = {
+    repository: {
       type: 'git',
-      url: `git+${remoteURL}`,
-    }
+      url: `git+https://github.com/npm/init-package-json.git`,
+    },
+    main: 'index.js',
   }
 
   t.has(data, wanted)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

```diff
- gconf = gconf.split(/\r?\n/)
+ const gconf = await fs.readFile('.git/config', 'utf8').catch(() => '')
+ const lines = gconf.split(/\r?\n/)
`````

In #186, there was breaking change in retrieving repository URL from `.git/config`.

Although the split lines were assigned to `lines`, the code still accessed `gconf` to get the file lines, causing the repository field to never auto-complete.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
