### PR TITLE
feat: explicitly include type

### DIFF
--- a/lib/init-package-json.js
+++ b/lib/init-package-json.js
@@ -100,6 +100,10 @@ async function init (dir,
     delete pkg.content.repository
   }
 
+  if (!pkg.content.type) {
+    pkg.content.type = 'commonjs'    
+  }
+
   // readJson filters out empty descriptions, but init-package-json
   // traditionally leaves them alone
   if (!pkg.content.description) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -26,6 +26,7 @@ t.test('the basics', async (t) => {
     main: 'main.js',
     config: { foo: 'bar' },
     package: {},
+    type: 'commonjs',
   })
 })
 
@@ -47,6 +48,7 @@ t.test('no config', async (t) => {
     main: 'main.js',
     config: {},
     package: {},
+    type: 'commonjs',
   })
 })
 

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -42,6 +42,7 @@ t.test('read in dependencies and dev deps', async (t) => {
     main: 'index.js',
     keywords: [],
     license: 'ISC',
+    type: 'commonjs',
     dependencies: {
       tap: '*',
     },

--- a/test/npm-defaults.js
+++ b/test/npm-defaults.js
@@ -101,6 +101,7 @@ const EXPECTED = {
   keywords: [],
   author: 'npmbot <n@p.m> (http://npm.im/)',
   license: 'WTFPL',
+  type: 'commonjs',
 }
 
 t.test('npm configuration values pulled from environment', async t => {


### PR DESCRIPTION
I've read through several issues in both `npm/cli` and `npm/rfcs` and there seems to be universal agreement that adding `"type": "commonjs"` would be an improvement as it's better to explicit than implicit both for understandability and to improve performance by eliminating the need to go down detection code paths.

Several people have also suggested prompting for the `type` field and that is much more controversial and has been decided against, so I have not done that.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References

https://github.com/npm/rfcs/discussions/75#discussioncomment-11943

From https://nodejs.org/en/blog/release/v20.10.0:
> Detection increases startup time, so we encourage everyone—especially package authors—to add a type field to package.json, even for the default "type": "commonjs".

https://publint.dev/ and the `publint` package also validate that the `type` field is present and warn package authors if it is not. It would be best to create a `package.json` without warnings out of the box: https://github.com/bluwy/publint/blob/master/site/rules.md#use_type

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
