### PR TITLE
feat: adds type

### DIFF
--- a/lib/default-input.js
+++ b/lib/default-input.js
@@ -261,17 +261,7 @@ exports.license = yes ? license : prompt('license', license, (data) => {
   return invalid(`Sorry, ${errors.join(' and ')}.`)
 })
 
-function validateType (type) {
-  if (['commonjs', 'module'].includes(type)) {
-    return type
-  }
-  throw new Error(`${type} is not a valid package "type" (must be "commonjs" or "module")`)
-}
 const type = package.type || getConfig('type') || 'commonjs'
-exports.type = yes ? validateType(type) : prompt('type', type, (data) => {
-  try {
-    return validateType(data)
-  } catch (e) {
-    return invalid(e.message)
-  }
+exports.type = yes ? type : prompt('type', type, (data) => {
+  return data
 })

--- a/lib/default-input.js
+++ b/lib/default-input.js
@@ -260,3 +260,18 @@ exports.license = yes ? license : prompt('license', license, (data) => {
   const errors = (its.errors || []).concat(its.warnings || [])
   return invalid(`Sorry, ${errors.join(' and ')}.`)
 })
+
+function validateType (type) {
+  if (['commonjs', 'module'].includes(type)) {
+    return type
+  }
+  throw new Error(`${type} is not a valid package "type" (must be "commonjs" or "module")`)
+}
+const type = package.type || getConfig('type') || 'commonjs'
+exports.type = yes ? validateType(type) : prompt('type', type, (data) => {
+  try {
+    return validateType(data)
+  } catch (e) {
+    return invalid(e.message)
+  }
+})

--- a/lib/init-package-json.js
+++ b/lib/init-package-json.js
@@ -139,7 +139,7 @@ async function init (dir,
     return
   }
 
-  await pkg.save()
+  await pkg.save({ sort: true })
   return pkg.content
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "description": "A node module to get your node module started",
   "dependencies": {
-    "@npmcli/package-json": "^6.0.0",
+    "@npmcli/package-json": "^6.1.0",
     "npm-package-arg": "^12.0.0",
     "promzard": "^2.0.0",
     "read": "^4.0.0",

--- a/test/bins.js
+++ b/test/bins.js
@@ -10,18 +10,9 @@ t.test('auto bin population', async (t) => {
     testdir: {
       bin: { 'run.js': '' },
     },
-    inputs: [
-      'auto-bin-test',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      'yes',
-    ],
+    inputs: {
+      name: 'auto-bin-test',
+    },
   })
   t.same(data.bin, { 'auto-bin-test': 'bin/run.js' },
     'bin auto populated with correct path')

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -36,6 +36,7 @@ t.test('read in dependencies and dev deps', async (t) => {
   t.same(data, {
     name: 'tap-testdir-dependencies-read-in-dependencies-and-dev-deps',
     version: '1.0.0',
+    type: 'commonjs',
     description: '',
     author: '',
     scripts: { test: 'mocha' },

--- a/test/fixtures/setup.js
+++ b/test/fixtures/setup.js
@@ -18,6 +18,8 @@ const setup = async (t, file, {
     tdir = path.join(tdir, dir)
   }
 
+  inputs = Array.isArray(inputs) ? inputs : validInput(inputs)
+
   const args = [file, CHILD, tdir, inputFile]
   if (config) {
     args.push(JSON.stringify(config))
@@ -73,6 +75,29 @@ async function child ({ chdir } = {}) {
   if (output !== undefined) {
     console.error(JSON.stringify(output))
   }
+}
+
+const standardValue = (value) => {
+  if (Array.isArray(value) && Array.isArray(value[0])) {
+    return value
+  }
+  return [value]
+}
+
+const validInput = (obj) => {
+  return [
+    ...standardValue(obj.name || ''),
+    ...standardValue(obj.version || ''),
+    ...standardValue(obj.description || ''),
+    ...standardValue(obj.entry || ''),
+    ...standardValue(obj.test || ''),
+    ...standardValue(obj.repo || ''),
+    ...standardValue(obj.keywords || ''),
+    ...standardValue(obj.author || ''),
+    ...standardValue(obj.licence || ''),
+    ...standardValue(obj.type || ''),
+    ...standardValue(obj.ok || 'yes'),
+  ]
 }
 
 module.exports = { setup, child, isChild, getFixture }

--- a/test/license.js
+++ b/test/license.js
@@ -7,19 +7,13 @@ if (isChild()) {
 
 t.test('license', async (t) => {
   const { data } = await setup(t, __filename, {
-    inputs: [
-      'the-name', // package name
-      '', // version
-      '', // description
-      '', // entry point
-      '', // test
-      '', // git repo
-      '', // keywords
-      '', // author
-      [/license: \(.*\) $/, 'Apache'], // invalid license
-      [/license: \(.*\) $/, 'Apache-2.0'], // license
-      'yes', // about to write
-    ],
+    inputs: {
+      name: 'the-name',
+      licence: [
+        [/license: \(.*\) $/, 'Apache'], // invalid license
+        [/license: \(.*\) $/, 'Apache-2.0'], // license
+      ],
+    },
   })
 
   const wanted = {

--- a/test/name-spaces.js
+++ b/test/name-spaces.js
@@ -7,19 +7,12 @@ if (isChild()) {
 
 t.test('single space', async t => {
   const { data } = await setup(t, __filename, {
-    inputs: [
-      [/name: \(.*\) $/, 'the name'], // invalid package name
-      [/name: \(.*\) $/, 'the-name'], // package name
-      '', // version
-      '', // description
-      '', // entry point
-      '', // test
-      '', // git repo
-      '', // keywords
-      '', // author
-      '', // license
-      'yes', // about to write
-    ],
+    inputs: {
+      name: [
+        [/name: \(.*\) $/, 'the name'], // invalid package name
+        [/name: \(.*\) $/, 'the-name'], // package name
+      ],
+    },
   })
 
   const wanted = {
@@ -36,19 +29,12 @@ t.test('single space', async t => {
 
 t.test('multiple spaces', async t => {
   const { data } = await setup(t, __filename, {
-    inputs: [
-      [/name: \(.*\) $/, 'the name should be this'], // invalid package name
-      [/name: \(.*\) $/, 'the-name-should-be-this'], // package name
-      '', // version
-      '', // description
-      '', // entry point
-      '', // test
-      '', // git repo
-      '', // keywords
-      '', // author
-      '', // license
-      'yes', // about to write
-    ],
+    inputs: {
+      name: [
+        [/name: \(.*\) $/, 'the name should be this'], // invalid package name
+        [/name: \(.*\) $/, 'the-name-should-be-this'], // package name
+      ],
+    },
   })
 
   const wanted = {

--- a/test/name-uppercase.js
+++ b/test/name-uppercase.js
@@ -7,19 +7,12 @@ if (isChild()) {
 
 t.test('uppercase', async (t) => {
   const { data } = await setup(t, __filename, {
-    inputs: [
-      [/name: \(.*\) $/, 'THE-NAME'],
-      [/name: \(.*\) $/, 'the-name'],
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      'yes',
-    ],
+    inputs: {
+      name: [
+        [/name: \(.*\) $/, 'THE-NAME'],
+        [/name: \(.*\) $/, 'the-name'],
+      ],
+    },
   })
 
   const EXPECT = {

--- a/test/npm-defaults.js
+++ b/test/npm-defaults.js
@@ -100,6 +100,7 @@ const EXPECTED = {
   },
   keywords: [],
   author: 'npmbot <n@p.m> (http://npm.im/)',
+  type: 'commonjs',
   license: 'WTFPL',
 }
 

--- a/test/repository.js
+++ b/test/repository.js
@@ -7,18 +7,7 @@ if (isChild()) {
 
 t.test('license', async (t) => {
   const { data } = await setup(t, __filename, {
-    inputs: [
-      'the-name', // package name
-      '', // version
-      '', // description
-      '', // entry point
-      '', // test
-      'npm/cli', // git repo
-      '', // keywords
-      '', // author
-      '', // license
-      'yes', // about to write
-    ],
+    inputs: { name: 'the-name', repo: 'npm/cli' },
   })
 
   const wanted = {
@@ -32,6 +21,7 @@ t.test('license', async (t) => {
       url: 'git+https://github.com/npm/cli.git',
     },
     main: 'index.js',
+    type: 'commonjs',
   }
   t.has(data, wanted)
 })


### PR DESCRIPTION
Adds `type` to `package.json` for use when running `npm init`. 

1. Defaults to `commonjs`
2. Validates against `commonjs` | `module`
3. Allows `npm init --init-type module -y` 
4. Allows for `init.type=module` in `.npmrc`
5. Improved tests to make it easier to manage removing / adding new prompts
6. Utilizes new sort package.json feature

on the shoulders of https://github.com/npm/init-package-json/pull/302
a part of the npm 11 roadmap https://github.com/npm/statusboard/issues/898
statusboard issue here https://github.com/npm/statusboard/issues/654
older rfc https://github.com/npm/rfcs/issues/347

> Note: Running `npm init --init-type=module -y` will not overwrite an existing `package.json` type field. This is deemed out of scope for `init`. To update an existing `type` edit it manually or field, use `jq '.type = "module"' package.json > tmp.json && mv tmp.json package.json`.