### PR TITLE
fix: default git repository value if exist

### DIFF
--- a/lib/default-input.js
+++ b/lib/default-input.js
@@ -199,16 +199,17 @@ if (!package.scripts) {
 
 if (!package.repository) {
   exports.repository = async () => {
-    const gconf = await fs.readFile('.git/config', 'utf8').catch(() => '')
+    const gitConfigPath = path.resolve(dirname, '.git', 'config')
+    const gconf = await fs.readFile(gitConfigPath, 'utf8').catch(() => '')
     const lines = gconf.split(/\r?\n/)
 
     let url
     const i = lines.indexOf('[remote "origin"]')
 
     if (i !== -1) {
-      url = gconf[i + 1]
+      url = lines[i + 1]
       if (!url.match(/^\s*url =/)) {
-        url = gconf[i + 2]
+        url = lines[i + 2]
       }
       if (!url.match(/^\s*url =/)) {
         url = null

--- a/test/repository.js
+++ b/test/repository.js
@@ -35,3 +35,23 @@ t.test('license', async (t) => {
   }
   t.has(data, wanted)
 })
+
+t.test('repository from git config', async (t) => {
+  const testdir = {
+    '.git': {
+      config: `
+[remote "origin"]
+  url = https://github.com/npm/cli.git`,
+    } }
+
+  const { data } = await setup(t, __filename, {
+    config: { yes: 'yes' },
+    testdir,
+  })
+
+  const wanted = {
+    type: 'git',
+    url: 'git+https://github.com/npm/cli.git',
+  }
+  t.has(data.repository, wanted)
+})


### PR DESCRIPTION
Fix for correctly inspect git config value and use remote repository url as repository value in default pacakage json value 

Fixes https://github.com/npm/cli/issues/7940

Testing 
```sh
~/workarea/test-repo $ lnpm init -y
Wrote to /Users/milaninfy/workarea/test-repo/package.json:

{
  "name": "test-repo",
  "version": "1.0.0",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "repository": {
    "type": "git",
    "url": "git+https://github.com/milaninfy/test-repo.git"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "bugs": {
    "url": "https://github.com/milaninfy/test-repo/issues"
  },
  "homepage": "https://github.com/milaninfy/test-repo#readme",
  "description": ""
}
```

