### PR TITLE
feat: adds init-private option to config

### DIFF
--- a/lib/default-input.js
+++ b/lib/default-input.js
@@ -266,3 +266,8 @@ const type = package.type || getConfig('type') || 'commonjs'
 exports.type = yes ? type : prompt('type', type, (data) => {
   return data
 })
+
+const initPrivate = getConfig('private')
+if (initPrivate !== undefined) {
+  exports.private = initPrivate
+}

--- a/test/private-defaults.js
+++ b/test/private-defaults.js
@@ -1,0 +1,30 @@
+const t = require('tap')
+const { setup, child, isChild } = require('./fixtures/setup')
+
+if (isChild()) {
+  return child()
+}
+
+t.test('private field with init-private true', async (t) => {
+  const { data } = await setup(t, __filename, {
+    config: { yes: 'yes', 'init-private': true },
+  })
+
+  t.equal(data.private, true, 'private field set to true in yes mode')
+})
+
+t.test('private field with init-private false', async (t) => {
+  const { data } = await setup(t, __filename, {
+    config: { yes: 'yes', 'init-private': false },
+  })
+
+  t.equal(data.private, false, 'private field set to false in yes mode')
+})
+
+t.test('private field without init-private', async (t) => {
+  const { data } = await setup(t, __filename, {
+    config: { yes: 'yes' },
+  })
+
+  t.equal(data.private, undefined, 'private not set in by default')
+})


### PR DESCRIPTION
https://github.com/npm/cli/pull/8246

This pull request introduces support for an `init-private` configuration option, allowing users to specify whether a package should be private by default. It includes changes to the initialization logic and corresponding test cases to ensure the feature works as expected.