### PR TITLE
fix!: stop auto populating dependencies

### DIFF
--- a/lib/default-input.js
+++ b/lib/default-input.js
@@ -7,46 +7,7 @@ const validateName = require('validate-npm-package-name')
 const npa = require('npm-package-arg')
 const semver = require('semver')
 
-// more popular packages should go here, maybe?
-const testPkgs = [
-  'coco',
-  'coffee-script',
-  'expresso',
-  'jasmine',
-  'jest',
-  'mocha',
-  'streamline',
-  'tap',
-]
-const isTestPkg = p => testPkgs.includes(p)
-
 const invalid = (msg) => Object.assign(new Error(msg), { notValid: true })
-
-const readDeps = (test, excluded) => async () => {
-  const dirs = await fs.readdir('node_modules').catch(() => null)
-
-  if (!dirs) {
-    return
-  }
-
-  const deps = {}
-  for (const dir of dirs) {
-    if (dir.match(/^\./) || test !== isTestPkg(dir) || excluded[dir]) {
-      continue
-    }
-
-    const dp = path.join(dirname, 'node_modules', dir, 'package.json')
-    const p = await fs.readFile(dp, 'utf8').then((d) => JSON.parse(d)).catch(() => null)
-
-    if (!p || !p.version || p?._requiredBy?.some((r) => r === '#USER')) {
-      continue
-    }
-
-    deps[dir] = config.get('save-exact') ? p.version : config.get('save-prefix') + p.version
-  }
-
-  return deps
-}
 
 const getConfig = (key) => {
   // dots take precedence over dashes
@@ -165,14 +126,6 @@ exports.directories = async () => {
   }, {})
 
   return Object.keys(res).length === 0 ? undefined : res
-}
-
-if (!package.dependencies) {
-  exports.dependencies = readDeps(false, package.devDependencies || {})
-}
-
-if (!package.devDependencies) {
-  exports.devDependencies = readDeps(true, package.dependencies || {})
 }
 
 // MUST have a test script!

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -5,7 +5,7 @@ if (isChild()) {
   return child({ chdir: true })
 }
 
-t.test('read in dependencies and dev deps', async (t) => {
+t.test('existing dependencies', async (t) => {
   const testdirContents = {
     'package.json': JSON.stringify({
       dependencies: {
@@ -16,16 +16,6 @@ t.test('read in dependencies and dev deps', async (t) => {
         abbrev: '*',
       },
     }),
-    node_modules: {},
-  }
-
-  for (const fakedep of ['mocha', 'tap', 'async', 'foobar']) {
-    testdirContents.node_modules[fakedep] = {
-      'package.json': JSON.stringify({
-        name: fakedep,
-        version: '1.0.0',
-      }),
-    }
   }
 
   const { data } = await setup(t, __filename, {
@@ -34,23 +24,35 @@ t.test('read in dependencies and dev deps', async (t) => {
   })
 
   t.same(data, {
-    name: 'tap-testdir-dependencies-read-in-dependencies-and-dev-deps',
+    name: 'tap-testdir-dependencies-existing-dependencies',
     version: '1.0.0',
     type: 'commonjs',
     description: '',
     author: '',
-    scripts: { test: 'mocha' },
+    scripts: { test: 'echo "Error: no test specified" && exit 1' },
     main: 'index.js',
     keywords: [],
     license: 'ISC',
     dependencies: {
       tap: '*',
     },
-    devDependencies: {
-      mocha: '^1.0.0',
-    },
     optionalDependencies: {
       abbrev: '*',
     },
   }, 'used the correct dependency information')
+})
+
+t.test('delete empty dependencies', async (t) => {
+  const testdirContents = {
+    'package.json': JSON.stringify({
+      dependencies: {},
+    }),
+  }
+
+  const { data } = await setup(t, __filename, {
+    testdir: testdirContents,
+    config: { yes: 'yes', 'save-prefix': '^' },
+  })
+
+  t.same(data.dependencies, undefined, 'empty dependencies is removed')
 })


### PR DESCRIPTION
BREAKING CHANGE: existing packages in `node_modules` are no longer used to try to pre-populate dependencies and devDependencies

fixes https://github.com/npm/statusboard/issues/1075