### PR TITLE
feat!: omit license field by default when initializing package.json

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,10 +32,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -53,10 +53,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -131,10 +127,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Add Problem Matcher

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -97,10 +93,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Add Problem Matcher

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -30,10 +30,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -47,10 +47,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Set npm authToken

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -121,10 +117,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text

--- a/lib/default-input.js
+++ b/lib/default-input.js
@@ -262,13 +262,27 @@ if (!package.author) {
     : yes ? '' : prompt('author')
 }
 
-const license = package.license || getConfig('license') || 'ISC'
-exports.license = yes ? license : prompt('license', license, (data) => {
-  if (validateLicense(data)) {
-    return data
+const configLicense = getConfig('license')
+const license = package.license || configLicense || undefined
+
+if (yes) {
+  // Only include license if explicitly set in config or already in package.json
+  if (license) {
+    exports.license = license
   }
-  return invalid('Sorry, license should be a valid SPDX license expression')
-})
+} else {
+  exports.license = prompt('license', license || undefined, (data) => {
+    if (!data) {
+      return undefined
+    }
+    if (validateLicense(data)) {
+      return data
+    }
+    return invalid(
+      'License should be a valid SPDX license expression'
+    )
+  })
+}
 
 const type = package.type || getConfig('type') || 'commonjs'
 exports.type = yes ? type : prompt('type', type, (data) => {

--- a/lib/init-package-json.js
+++ b/lib/init-package-json.js
@@ -100,6 +100,11 @@ async function init (dir,
     delete pkg.content.repository
   }
 
+  // if no license was explicitly provided, don't include one
+  if (!pzData.license) {
+    delete pkg.content.license
+  }
+
   // readJson filters out empty descriptions, but init-package-json
   // traditionally leaves them alone
   if (!pkg.content.description) {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
     "version": "4.30.0",
-    "publish": true
+    "publish": true,
+    "updateNpm": false
   }
 }

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -42,7 +42,6 @@ t.test('read in dependencies and dev deps', async (t) => {
     scripts: { test: 'mocha' },
     main: 'index.js',
     keywords: [],
-    license: 'ISC',
     dependencies: {
       tap: '*',
     },

--- a/test/license.js
+++ b/test/license.js
@@ -10,8 +10,8 @@ t.test('license', async (t) => {
     inputs: {
       name: 'the-name',
       licence: [
-        [/license: \(.*\) $/, 'Apache'], // invalid license
-        [/license: \(.*\) $/, 'Apache-2.0'], // license
+        [/license: $/, 'Apache'], // invalid license
+        [/license: $/, 'Apache-2.0'], // license
       ],
     },
   })
@@ -26,4 +26,40 @@ t.test('license', async (t) => {
     main: 'index.js',
   }
   t.has(data, wanted)
+})
+
+t.test('license omitted when left blank', async (t) => {
+  const { data } = await setup(t, __filename, {
+    inputs: {
+      name: 'the-name',
+      licence: [
+        [/license: $/, ''], // leave blank
+      ],
+    },
+  })
+
+  t.equal(data.license, undefined, 'license is omitted when left blank')
+})
+
+t.test('license from config', async (t) => {
+  const { data } = await setup(t, __filename, {
+    config: { yes: 'yes', 'init-license': 'MIT' },
+  })
+
+  t.equal(data.license, 'MIT', 'uses configured license')
+})
+
+t.test('license preserved from existing package.json', async (t) => {
+  const { data } = await setup(t, __filename, {
+    testdir: {
+      'package.json': JSON.stringify({
+        name: 'existing-package',
+        version: '1.0.0',
+        license: 'BSD-3-Clause',
+      }),
+    },
+    config: { yes: 'yes' },
+  })
+
+  t.equal(data.license, 'BSD-3-Clause', 'preserves existing license')
 })

--- a/test/name-spaces.js
+++ b/test/name-spaces.js
@@ -20,7 +20,6 @@ t.test('single space', async t => {
     version: '1.0.0',
     description: '',
     scripts: { test: 'echo "Error: no test specified" && exit 1' },
-    license: 'ISC',
     author: '',
     main: 'index.js',
   }
@@ -42,7 +41,6 @@ t.test('multiple spaces', async t => {
     version: '1.0.0',
     description: '',
     scripts: { test: 'echo "Error: no test specified" && exit 1' },
-    license: 'ISC',
     author: '',
     main: 'index.js',
   }

--- a/test/name-uppercase.js
+++ b/test/name-uppercase.js
@@ -20,7 +20,6 @@ t.test('uppercase', async (t) => {
     version: '1.0.0',
     description: '',
     scripts: { test: 'echo "Error: no test specified" && exit 1' },
-    license: 'ISC',
     author: '',
     main: 'index.js',
   }

--- a/test/scope-in-config.js
+++ b/test/scope-in-config.js
@@ -14,7 +14,6 @@ t.test('--yes with scope', async (t) => {
     scripts: { test: 'echo "Error: no test specified" && exit 1' },
     main: 'index.js',
     keywords: [],
-    license: 'ISC',
   }
 
   const { data } = await setup(t, __filename, {

--- a/test/yes-defaults.js
+++ b/test/yes-defaults.js
@@ -14,7 +14,6 @@ t.test('--yes defaults', async (t) => {
     scripts: { test: 'echo "Error: no test specified" && exit 1' },
     main: 'index.js',
     keywords: [],
-    license: 'ISC',
   }
 
   const { data } = await setup(t, __filename, {
@@ -22,4 +21,5 @@ t.test('--yes defaults', async (t) => {
   })
 
   t.has(data, EXPECT, 'used the default data')
+  t.equal(data.license, undefined, 'license is omitted by default')
 })


### PR DESCRIPTION
BREAKING CHANGE: The license field is no longer included by default when running `npm init` or `npm init --yes`. If you want to include a license, you can either set it in your npm config (`npm set init-license=MIT`) or provide it interactively when running `npm init`.